### PR TITLE
LDS-5800 : Add back merge main -> develop

### DIFF
--- a/.github/workflows/back-merge.yml
+++ b/.github/workflows/back-merge.yml
@@ -1,0 +1,37 @@
+name: Back merge
+
+# Back-merge main → develop pour les pushs sur main HORS release
+# (typiquement un hotfix mergé directement sur main).
+#
+# Les releases sont gérées par perform-release.yml, qui lance le bot en step inline.
+# Pas de doublon : perform-release pousse main avec le GITHUB_TOKEN intégré, et un
+# push fait avec ce token ne déclenche AUCUN workflow (anti-récursion GitHub). Donc
+# ce workflow ne se déclenche QUE sur les pushs "humains" (hotfix), jamais en release.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:        # déclenchement manuel de secours
+
+permissions:
+  contents: read            # le bot fait ses writes via son propre token App
+
+jobs:
+  back-merge:
+    name: Back merge main into develop
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0              # toutes les branches divergentes
+          persist-credentials: false  # le bot gère l'auth git via son token App
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Back merge main into develop
+        env:
+          GITHUB_APP_ID: ${{ vars.LCDP_BACKMERGE_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.LCDP_BACKMERGE_APP_PRIVATE_KEY }}
+          AUTO_MERGE_TARGET_PATTERNS: "develop"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: uvx lcdp-back-merge

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -1,7 +1,7 @@
 name: perform-release
 
 # Must be triggered from a release/v* branch.
-# merge into main → tag → delete release branch → merge main into develop → build & publish app.
+# merge into main → tag → delete release branch → back-merge main into develop (bot) → build & publish app.
 
 on:
   workflow_dispatch:
@@ -65,20 +65,23 @@ jobs:
           git tag -a -m "Tagging for release $NEW_VERSION" "$NEW_VERSION"
           git push origin "$NEW_VERSION"
 
-      - name: Back-merge main into develop via PR
+      # Back-merge main → develop via le bot lcdp-back-merge (PR + résolution IA
+      # des conflits) plutôt qu'un merge brut qui ferait planter la release au
+      # moindre conflit. Le bot crée une PR auto-merge/main-into-develop et
+      # l'auto-merge si le merge est propre (ou high-confidence après IA).
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Back merge main into develop
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEW_VERSION: ${{ steps.version.outputs.new_version }}
-        run: |
-          BACK_MERGE_BRANCH="chore/back-merge-main-${NEW_VERSION}"
-          git checkout -b "$BACK_MERGE_BRANCH" main
-          git push origin "$BACK_MERGE_BRANCH"
-          gh pr create \
-            --base develop \
-            --head "$BACK_MERGE_BRANCH" \
-            --title "Back-merge main into develop after ${NEW_VERSION}" \
-            --body "Automated back-merge after release ${NEW_VERSION}."
-          gh pr merge "$BACK_MERGE_BRANCH" --merge --delete-branch
+          # Le workflow est déclenché sur release/vX → on FORCE main comme branche
+          # source (le bot lit la source depuis GITHUB_REF_NAME).
+          GITHUB_REF_NAME: main
+          GITHUB_APP_ID: ${{ vars.LCDP_BACKMERGE_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.LCDP_BACKMERGE_APP_PRIVATE_KEY }}
+          AUTO_MERGE_TARGET_PATTERNS: "develop"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: uvx lcdp-back-merge
 
   build-and-publish:
     name: Build and publish release


### PR DESCRIPTION
Reproduit la modif back-merge de lcdp-deployment-manager (workflow GitHub) :
- ajoute .github/workflows/back-merge.yml (bot lcdp-back-merge sur push main hors release)
- remplace le back-merge gh-pr de perform-release.yml par le bot lcdp-back-merge Adapte master -> main (branche principale d'inventorist-app).