### PR TITLE
LDS-5768: run the branch CI on release/* before tagging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - 'feature/**'
       - 'bugfix/**'
       - 'hotfix/**'
+      - 'release/**'
 jobs:
   Test_application:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Contexte

Le commit de bump créé par l'outil de release (`03_patch` + `04_lock`) n'est relu par personne et n'a jamais vu la CI : la branche `release/vX.Y.Z` ne matche aucun trigger, et `perform-release` merge dans `main` puis tague dans la foulée.

## Changement

Une ligne : `release/**` ajouté aux `push.branches` de `test.yml`.

La CI (`uv sync --frozen` + pytest) tourne donc sur le commit de bump — ce qui valide aussi que le `uv.lock` régénéré s'installe — avant que le tag ne soit posé.

## Côté orchestrateur

La nouvelle étape `05b` de `lcdp-release` attend que ces workflows soient verts avant de passer la main à `perform-release`. À merger **avant** la PR `lcdp-versioning#feature/LDS-5768-e2e-gate`, qui active le flag `validate_on_branch` sur ce repo : sans cette PR-ci, aucun workflow ne démarrerait sur `release/**` et l'étape échouerait au bout du timeout.

Ticket : https://lecomptoirdespharmacies.atlassian.net/browse/LDS-5768