### PR TITLE
LDS-6078: bump lcdp-api to 1.20.0 for the restrictedFeatures enum array

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "envsubst==0.1.5",
     "Pillow==12.2.0",
     "python-rest-client-codegen==1.10.5",
-    "lcdp-api==1.15.0.post2+git.bd98e275",
+    "lcdp-api==1.20.0",
     "urllib3==2.2.3",
     "certifi",
     "python-dateutil==2.8.2",

--- a/uv.lock
+++ b/uv.lock
@@ -235,11 +235,11 @@ wheels = [
 
 [[package]]
 name = "lcdp-api"
-version = "1.15.0.post2+git.bd98e275"
-source = { registry = "https://pypi.fury.io/lcdp/" }
-sdist = { url = "https://pypi.fury.io/lcdp/-/ver_1jLXVM/lcdp_api-1.15.0.post2+git.bd98e275.tar.gz", hash = "sha256:b09ee44a4a9d56304371d8982d4e492f4cfc188959740dcde65ddd0ce129072b" }
+version = "1.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/ef/f479db6c0934c56d5da5cd641a0985dc7edfd9285ad437e9715263e50104/lcdp_api-1.20.0.tar.gz", hash = "sha256:d0c98a37d21a45dd6ef56e8b953582c65b5ccfe11d8b2640775d8fa4af12a32d", size = 81648, upload-time = "2026-08-10T13:59:17.436Z" }
 wheels = [
-    { url = "https://pypi.fury.io/lcdp/-/ver_Mlnj9/lcdp_api-1.15.0.post2+git.bd98e275-py3-none-any.whl", hash = "sha256:6f7a04998626566897f7e43ae53d05c698ef7b7281dd98cfd8eb239cb6f18c1d" },
+    { url = "https://files.pythonhosted.org/packages/b3/fd/031057aa333ccc3a8aad0d639dfb056a3ff3dbe85491d3f2eef5dc58045e/lcdp_api-1.20.0-py3-none-any.whl", hash = "sha256:a8de9f94912db68699ad503e021c206e34f078dcb5db67749d83e026cdfe2440", size = 126387, upload-time = "2026-08-10T13:59:16.533Z" },
 ]
 
 [[package]]
@@ -280,7 +280,7 @@ requires-dist = [
     { name = "envsubst", specifier = "==0.1.5" },
     { name = "flatten-json", specifier = "==0.1.14" },
     { name = "keyring", specifier = "==23.4.0" },
-    { name = "lcdp-api", specifier = "==1.15.0.post2+git.bd98e275" },
+    { name = "lcdp-api", specifier = "==1.20.0" },
     { name = "openpyxl", specifier = "==3.1.3" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "psutil", specifier = "==7.0.0" },


### PR DESCRIPTION
## Contexte

L'app desktop Inventorist plante à l'authentification en prod (release `v2.2.0`) : la désérialisation de `get_current_user` (`/users/me`) échoue sur `User.restrictedFeatures`, reçu comme tableau d'enum (`['CART_PROFIT']`) alors que le client Python généré attend un objet `HttpLink`.

Ticket : [LDS-6078](https://lecomptoirdespharmacies.atlassian.net/browse/LDS-6078) · [Sentry LCDP-INVENTORIST-50](https://le-comptoir-des-pharmacies.sentry.io/issues/LCDP-INVENTORIST-50)

## Cause

`api/consume/gen/` n'est pas versionné : il est généré au packaging par `prepare.py` → `generate_consumer("user.yaml")`, à partir de la spec livrée par le paquet `lcdp-api`. `develop` épinglait le snapshot `lcdp-api==1.15.0.post2+git.bd98e275`, dont `rest/user.yaml` déclare encore :

```yaml
restrictedFeatures:
  $ref: 'common.yaml#/components/schemas/HttpLink'
```

alors que l'API renvoie un tableau d'enum depuis LDS-5525. Le modèle généré appelle donc `HttpLink.from_dict()` sur une liste → `ValidationError`.

## Changement

Bump de `lcdp-api` `1.15.0.post2+git.bd98e275` → **`1.20.0`** dans `pyproject.toml`, et l'entrée correspondante dans `uv.lock`. Rien d'autre.

`1.20.0` est la dernière version publiée sur PyPI et la **première** où `restrictedFeatures` est `type: array` / `items: RestrictedFeature` (1.16.0 → 1.19.0 sont encore en `HttpLink`). Aucune modification de la spec partagée `lcdp-api` n'est nécessaire : le correctif y est déjà publié. Même correctif que LDS-5975 côté `lcdp-smuggler`, qui épingle déjà `1.20.0`.

## Vérifications

Codegen rejoué localement avec la version de générateur **inchangée** par cette PR (`python-rest-client-codegen==1.10.5`), sur les deux specs :

| Spec | `user.py` généré |
|---|---|
| `lcdp-api` 1.15.2 (= prod `v2.2.0`) | `restricted_features: Optional[HttpLink]`, et `HttpLink.from_dict(obj["restrictedFeatures"])` **ligne 325** — exactement la frame de la stacktrace Sentry |
| `lcdp-api` 1.20.0 (cette PR) | `restricted_features: Optional[List[RestrictedFeature]]`, la liste passe directement dans `from_dict`, enum `RestrictedFeature.CART_PROFIT` généré |

Le bump du générateur n'est donc pas nécessaire et n'a pas été fait (hors périmètre).

Empreintes de `uv.lock` vérifiées contre l'API PyPI (`sha256`, `size`, `upload-time` de la wheel et du sdist). `uv lock` n'a pas pu être rejoué (pas de `uv` disponible sur le runner) : l'entrée a été alignée sur celle produite par `uv` pour ce même bump sur `release/v2.2.1`, et le diff des deux locks ne montre que les lignes `python-rest-client-codegen` volontairement laissées de côté. Build/tests non lancés localement (dépendances Python 3.12 non installables ici) — la CI `snapshot` valide au push.

## Note pour le relecteur

`release/v2.2.1` (non mergée, non taguée) porte déjà `lcdp-api==1.20.0` via son commit de release : si cette release part, le correctif arrive en prod par là. Cette PR corrige `develop`, qui portait encore un snapshot en `HttpLink` — donc les builds snapshot/staging plantaient aussi, et la prochaine release repartait d'une base cassée.


[LDS-6078]: https://lecomptoirdespharmacies.atlassian.net/browse/LDS-6078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ