### PR TITLE
LDS-6079: make the release merge-and-tag step replayable after a failed attempt

### DIFF
--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -42,6 +42,13 @@ jobs:
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
           echo "release_branch=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
 
+      # Rejouable de bout en bout : ce step échoue sur ce que l'automatisation ne peut
+      # pas trancher seule — typiquement un conflit release → main quand main porte un
+      # commit que develop n'a jamais reçu (back-merge manquant, vécu en v2.2.1). Une
+      # fois le conflit résolu à la main, relancer le workflow doit reprendre où il
+      # s'est arrêté, pas buter sur les traces de la tentative précédente.
+      # La branche release n'est supprimée qu'après le push du tag : c'est la seule ref
+      # depuis laquelle ce workflow peut être redéclenché (cf. Validate branch name).
       - name: Merge release branch into main via PR and tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -50,20 +57,40 @@ jobs:
         run: |
           COMMIT_DIFF=$(git rev-list main.."$RELEASE_BRANCH" | wc -l | tr -d ' ')
           if [ "$COMMIT_DIFF" -gt 0 ]; then
-            gh pr create \
-              --base main \
-              --head "$RELEASE_BRANCH" \
-              --title "Release $NEW_VERSION" \
-              --body "Automated release $NEW_VERSION."
-            gh pr merge "$RELEASE_BRANCH" --merge --delete-branch
+            # Une PR laissée ouverte par la tentative précédente est réutilisée :
+            # `gh pr create` échouerait sur "a pull request for branch ... already exists".
+            EXISTING_PR=$(gh pr list --head "$RELEASE_BRANCH" --base main --state open \
+              --json number --jq '.[0].number // empty')
+            if [ -n "$EXISTING_PR" ]; then
+              echo "Reusing open PR #$EXISTING_PR for $RELEASE_BRANCH."
+            else
+              gh pr create \
+                --base main \
+                --head "$RELEASE_BRANCH" \
+                --title "Release $NEW_VERSION" \
+                --body "Automated release $NEW_VERSION."
+            fi
+            gh pr merge "$RELEASE_BRANCH" --merge
           else
             echo "Release branch already merged into main, skipping PR creation."
           fi
           git fetch origin main
           git checkout main
           git pull --ff-only origin main
-          git tag -a -m "Tagging for release $NEW_VERSION" "$NEW_VERSION"
-          git push origin "$NEW_VERSION"
+          # Idempotent sur le tag aussi, mais jamais silencieux s'il désigne un autre
+          # commit : un tag déplacé changerait ce qui est buildé et publié.
+          EXISTING_TAG=$(git ls-remote --tags origin "refs/tags/$NEW_VERSION^{}" | cut -f1)
+          if [ -n "$EXISTING_TAG" ]; then
+            if [ "$EXISTING_TAG" != "$(git rev-parse HEAD)" ]; then
+              echo "::error::$NEW_VERSION already exists on $EXISTING_TAG, but main is now $(git rev-parse HEAD)"
+              exit 1
+            fi
+            echo "Tag $NEW_VERSION already points at main, skipping."
+          else
+            git tag -a -m "Tagging for release $NEW_VERSION" "$NEW_VERSION"
+            git push origin "$NEW_VERSION"
+          fi
+          git push origin --delete "$RELEASE_BRANCH" || true
 
       # Back-merge main → develop via le bot lcdp-back-merge (PR + résolution IA
       # des conflits) plutôt qu'un merge brut qui ferait planter la release au


### PR DESCRIPTION
## Contexte

La release v2.2.1 a échoué sur un conflit `release/v2.2.1` → `main` ([run](https://github.com/LeComptoirDesPharmacies/lcdp-inventorist-app/actions/runs/31700891040)) : `main` portait le bump de deps de v2.2.0 que `develop` n'avait jamais reçu, la PR de back-merge #184 ayant été fermée sans merge.

Le conflit lui-même n'est pas réparable par le workflow. En revanche, une fois résolu à la main, **relancer perform-release était impossible** : `gh pr create` échoue sur « a pull request for branch ... already exists ». Il a fallu merger la PR à la main puis relancer.

## Ce que fait cette PR

Rend le step `Merge release branch into main via PR and tag` rejouable :

- une PR ouverte laissée par la tentative précédente est **réutilisée** au lieu de faire échouer le step ;
- le tag n'est **posé que s'il n'existe pas**, et le step échoue explicitement s'il existe sur un autre commit — un tag déplacé changerait ce qui est buildé et publié ;
- la branche release n'est **supprimée qu'après le push du tag** : c'est la seule ref depuis laquelle ce workflow peut être redéclenché (`Validate branch name` exige `release/v*`). Avant, un échec au tag laissait la release irrécupérable par relance.

## Vérification

Les quatre scénarios ont été rejoués sur un dépôt jetable avec un stub `gh` : première tentative, relance avec PR déjà ouverte (le cas v2.2.1), relance avec tag déjà posé sur `main`, et tag existant sur un autre commit (échec attendu).

Le garde-fou qui empêche d'arriver dans cette situation est traité côté lcdp-release (préflight back-merge, même ticket).