### PR TITLE
LDS-6095: bump setup-uv to v10 so uv required-version >=0.11.22 resolves

### DIFF
--- a/.github/workflows/back-merge.yml
+++ b/.github/workflows/back-merge.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0              # toutes les branches divergentes
           persist-credentials: false  # le bot gère l'auth git via son token App
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v10
 
       - name: Back merge main into develop
         env:

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -70,7 +70,7 @@ jobs:
       # moindre conflit. Le bot crée une PR auto-merge/main-into-develop et
       # l'auto-merge si le merge est propre (ou high-confidence après IA).
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10
 
       - name: Back merge main into develop
         env:
@@ -118,7 +118,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"


### PR DESCRIPTION
La release v2.2.2 est bloquée : « Run python Test » échoue sur la branche release au step `astral-sh/setup-uv@v5` avec `No version found for >=0.11.22` ([run](https://github.com/LeComptoirDesPharmacies/lcdp-inventorist-app/actions/runs/32036890413), rejoué avec le même résultat). La liste de versions uv connue de `setup-uv@v5` (5 majeures de retard) s'arrête avant le `required-version >=0.11.22` du `pyproject.toml`.

**Correctif** : bump `astral-sh/setup-uv` v5 → v10 dans les 4 workflows — y compris `perform-release.yml`, qui aurait échoué au step suivant de la release.

Après merge, relancer l'orchestrateur (`--resume`) : la branche `release/v2.2.2` est re-cut depuis develop et récupérera le fix.

Ticket : [LDS-6095](https://lecomptoirdespharmacies.atlassian.net/browse/LDS-6095)


[LDS-6095]: https://lecomptoirdespharmacies.atlassian.net/browse/LDS-6095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ