### PR TITLE
LDS-6095: pin setup-uv to v10.0.1, no floating major tag past v7

### DIFF
--- a/.github/workflows/back-merge.yml
+++ b/.github/workflows/back-merge.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0              # toutes les branches divergentes
           persist-credentials: false  # le bot gère l'auth git via son token App
 
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
 
       - name: Back merge main into develop
         env:

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -70,7 +70,7 @@ jobs:
       # moindre conflit. Le bot crée une PR auto-merge/main-into-develop et
       # l'auto-merge si le merge est propre (ou high-confidence après IA).
       - name: Set up uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Back merge main into develop
         env:
@@ -118,7 +118,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"


### PR DESCRIPTION
Correction du fix précédent (#190) : `astral-sh/setup-uv@v10` ne se résout pas — setup-uv ne maintient plus d'alias majeur flottant au-delà de la v7 (seuls les tags précis `v10.0.1`, `v10.0.0`, `v9.0.0`… existent). Le run de la branche release échoue donc au setup du job : `Unable to resolve action astral-sh/setup-uv@v10` ([run](https://github.com/LeComptoirDesPharmacies/lcdp-inventorist-app/actions/runs/32047632585)).

**Correctif** : pin de la version complète `v10.0.1` dans les 4 workflows (vérifiée via `git ls-remote --tags`).

Ticket : [LDS-6095](https://lecomptoirdespharmacies.atlassian.net/browse/LDS-6095)


[LDS-6095]: https://lecomptoirdespharmacies.atlassian.net/browse/LDS-6095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ