### PR TITLE
LDS-6097: skip safe-chain age check on sync, age gate lives in uv lock

### DIFF
--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -125,8 +125,10 @@ jobs:
       - name: Install safe-chain
         run: npm install -g @aikidosec/safe-chain@1.5.7
       - name: Install dependencies
-        # Installs uv.lock exactly (age gate already frozen in); aikido-uv scans for malware.
-        run: aikido-uv sync --frozen
+        # Installs uv.lock exactly (age gate already frozen in by uv at lock time, internal
+        # packages exempt); skip safe-chain's own age check, redundant here — its malware
+        # scan stays active (LDS-6097).
+        run: aikido-uv sync --frozen --safe-chain-skip-minimum-package-age
       - uses: actions/setup-java@v4
         with:
           distribution: 'adopt'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -48,8 +48,10 @@ jobs:
       - name: Install safe-chain
         run: npm install -g @aikidosec/safe-chain@1.5.7
       - name: Install dependencies
-        # Installs uv.lock exactly (age gate already frozen in); aikido-uv scans for malware.
-        run: aikido-uv sync --frozen
+        # Installs uv.lock exactly (age gate already frozen in by uv at lock time, internal
+        # packages exempt); skip safe-chain's own age check, redundant here — its malware
+        # scan stays active (LDS-6097).
+        run: aikido-uv sync --frozen --safe-chain-skip-minimum-package-age
       - uses: actions/setup-java@v4
         with:
           distribution: 'adopt'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libjpeg-dev zlib1g-dev
       - name: Install dependencies
-        # Installs uv.lock exactly (age gate already frozen in); aikido-uv scans for malware.
-        run: aikido-uv sync --frozen
+        # Installs uv.lock exactly (age gate already frozen in by uv at lock time, internal
+        # packages exempt); skip safe-chain's own age check, redundant here — its malware
+        # scan stays active (LDS-6097).
+        run: aikido-uv sync --frozen --safe-chain-skip-minimum-package-age
       - name: Prepare app
         run: uv run python prepare.py
       - name: Run tests


### PR DESCRIPTION
Troisième blocage de la release v2.2.2 : `aikido-uv sync --frozen` échoue, safe-chain bloque le téléchargement de `python-rest-client-codegen 1.12.3` (publié le jour même) — `403 blocked by safe-chain direct download minimum package age` ([run](https://github.com/LeComptoirDesPharmacies/lcdp-inventorist-app/actions/runs/32107876518)).

C'est contraire à la politique supply-chain documentée (LDS-5825, `pyproject.toml [tool.uv]`) : le gate d'âge est appliqué **au lock** par uv (`exclude-newer = "1 week"`), les **packages internes en sont explicitement exemptés** (`exclude-newer-package`), et safe-chain n'est là que pour le scan malware. Son check d'âge au sync ignore ces exemptions : chaque release d'un package interne bloquerait la CI des consommateurs le jour J.

**Correctif** : `--safe-chain-skip-minimum-package-age` sur les trois `aikido-uv sync --frozen` (`test.yml`, `perform-release.yml`, `snapshot.yml`) — le flag que l'orchestrateur de release utilise déjà pour `aikido-uv lock`. Les versions restent figées par `--frozen`, le gate d'âge reste porté par uv au lock, le scan malware de safe-chain reste actif. Commentaires des steps mis à jour en conséquence.

Ticket : [LDS-6097](https://lecomptoirdespharmacies.atlassian.net/browse/LDS-6097)


[LDS-6097]: https://lecomptoirdespharmacies.atlassian.net/browse/LDS-6097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ